### PR TITLE
Add NIU to manufacturer database

### DIFF
--- a/data/manufacturers.php
+++ b/data/manufacturers.php
@@ -157,6 +157,7 @@ const MANUFACTURERS = [
     'PE3' => 'Mazda',
     'PL1' => 'Proton',
     'PNA' => 'NAZA (Peugeot)',
+    'R1N' => 'NIU',
     'RA1' => 'Steyr Trucks International FZE',
     'RFB' => 'Kymco',
     'RFG' => 'Sanyang SYM',


### PR DESCRIPTION
It's a Chinese electric scooter company. Couldn't find that R1N in any online databases, but it is the WMI in all ten sample VIN's I have.