### PR TITLE
updated region codes 6 and 7 to reflect Oceania and USA

### DIFF
--- a/data/regions.php
+++ b/data/regions.php
@@ -234,12 +234,13 @@ const REGIONS = [
         'region' => 'Oceania',
         'countries' => [
             'ABCDEFGHJKLMNPRSTUVW' => 'Australia',
+            'YZ1' => 'New Zealand',
         ],
     ],
     '7' => [
-        'region' => 'Oceania',
+        'region' => 'North America',
         'countries' => [
-            'ABCDE' => 'New Zealand',
+            'ABCDEFGHJKLMNPRSTUVWXYZ1234567890' => 'United States',
         ],
     ],
     '8' => [


### PR DESCRIPTION
According to [wikipedia](https://en.wikipedia.org/wiki/Vehicle_identification_number#World_manufacturer_identifier) and my trials with Tesla and Volvo models, codes 7 designate USA, e.g.
7JRZSL1VDNG165345 --> Volvo made in USA
7SAXCCE65PF392699 --> Tesla made in USA

I moved New Zealand to code 6, Y -1, where it seems to belong.